### PR TITLE
Removed usage of existing SAP ID

### DIFF
--- a/src/rest/impl/contracts.service.ts
+++ b/src/rest/impl/contracts.service.ts
@@ -572,7 +572,7 @@ export default class ContractsServiceImpl extends ContractsService {
           deliveryPlaceId,
           proposedDeliveryPlaceId,
           itemGroupId,
-          sapId || `${year}-${sapContract.DocNum}-${itemGroup.sapId}`,
+          `${year}-${sapContract.DocNum}-${itemGroup.sapId}`,
           contractQuantity || null,
           deliveredQuantity || null,
           proposedQuantity || null,


### PR DESCRIPTION
- it is better to just update the ID every time the contract is updated from SAP